### PR TITLE
1.4.1: Improvements to WindowsError::errno_desc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clipboard-win"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Douman <custparasite@gmx.se>"]
 description = "Utilities to interact with windows clipboard."
 repository = "https://github.com/DoumanAsh/clipboard-win"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+use winapi::{DWORD};
+
+// FormatMessage constants from https://msdn.microsoft.com/en-us/library/windows/desktop/ms679351%28v=vs.85%29.aspx
+pub const FORMAT_MESSAGE_ALLOCATE_BUFFER: DWORD = 0x00000100;
+pub const FORMAT_MESSAGE_ARGUMENT_ARRAY: DWORD = 0x00002000;
+pub const FORMAT_MESSAGE_FROM_HMODULE: DWORD = 0x00000800;
+pub const FORMAT_MESSAGE_FROM_STRING: DWORD = 0x00000400;
+pub const FORMAT_MESSAGE_FROM_SYSTEM: DWORD = 0x00001000;
+pub const FORMAT_MESSAGE_IGNORE_INSERTS: DWORD = 0x00000200;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,15 @@ extern crate kernel32;
 
 //WinAPI
 //functions
+use winapi::{DWORD};
 use kernel32::{FormatMessageW};
 
 //wrapper functions
 pub mod wrapper;
 use wrapper::{get_clipboard_seq_num};
+
+mod constants;
+use constants::*;
 
 use std::error::Error;
 use std::fmt;
@@ -49,11 +53,15 @@ impl WindowsError {
 
     ///Returns description of WinAPI error code.
     pub fn errno_desc(&self) -> String {
-        let mut format_buff: [u16; 300] = [0; 300];
-        let num_chars: u32 = unsafe { FormatMessageW(0x00000200 | 0x00001000 | 0x00002000,
+        const BUF_SIZE: usize = 512;
+        let mut format_buff: [u16; BUF_SIZE] = [0; BUF_SIZE];
+        let fmt_flags: DWORD = FORMAT_MESSAGE_IGNORE_INSERTS
+                             | FORMAT_MESSAGE_FROM_SYSTEM
+                             | FORMAT_MESSAGE_ARGUMENT_ARRAY;
+        let num_chars: u32 = unsafe { FormatMessageW(fmt_flags,
                                                      std::ptr::null(), self.0,
                                                      0, format_buff.as_mut_ptr(),
-                                                     200 as u32, std::ptr::null_mut()) };
+                                                     BUF_SIZE as u32, std::ptr::null_mut()) };
 
         if num_chars == 0 {
             return "Unknown error".to_string();


### PR DESCRIPTION
Add specific named constants for FormatMessageW flags, together with a link to the documentation.

Introduce a BUF_SIZE constant, and bump it to a power of 2.