### PR TITLE
Yield execution inbetween attempts to open

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,5 @@ features = [
     "winerror",
     "stringapiset",
     "errhandlingapi",
+    "processthreadsapi"
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ impl Clipboard {
                     _ => num -= 1,
                 }
             }
+            unsafe { winapi::um::processthreadsapi::SwitchToThread(); }
         }
     }
 }


### PR DESCRIPTION
Currently the `new_attempts_for` function doesn't give a chance to other threads or processes to let go of the clipboard.

Consider this: there's an application with two threads. thread A is using the clipboard, doing some operation on it. Now let's say that thread A gets suspended in the middle of the clipboard operation to give time for thread B to run. Now thread B starts running and tries to open the clipboard but it fails because thread A is holding it open. Thread B will keep trying to open the clipboard over and over again but it will always fail until thread A has a chance to finish what it's been doing.

`SwitchToThread` is identical to `std::thread::yield_now` (see the [implementaiton here](https://github.com/rust-lang/rust/blob/04f44fb9232dc960d213d0df4a203c387215a5ff/library/std/src/sys/windows/thread.rs#L79)) what they do is they tell the operating system that they are waiting for something to happen.