### PR TITLE
Setting list of files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,10 @@ default-target = "x86_64-pc-windows-msvc"
 [target.'cfg(windows)'.dependencies]
 error-code = "2.1"
 str-buf = "1"
+windows = { version = "0.43.0", features = ["Win32_UI_Shell", "Win32_Foundation"] }
 
-[features]
-std = ["error-code/std"]
+# [features]
+# std = ["error-code/std"]
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,9 @@ default-target = "x86_64-pc-windows-msvc"
 [target.'cfg(windows)'.dependencies]
 error-code = "2.1"
 str-buf = "1"
-windows = { version = "0.43.0", features = ["Win32_UI_Shell", "Win32_Foundation"] }
 
-# [features]
-# std = ["error-code/std"]
+[features]
+std = ["error-code/std"]
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -142,7 +142,7 @@ impl Getter<alloc::vec::Vec<std::path::PathBuf>> for FileList {
     }
 }
 
-impl<T: AsRef<str>> Setter<T> for FileList {
+impl<T: AsRef<[alloc::string::String]>> Setter<T> for FileList {
     #[inline(always)]
     fn write_clipboard(&self, data: &T) -> SysResult<()> {
         crate::raw::set_file_list(data.as_ref())

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -142,10 +142,10 @@ impl Getter<alloc::vec::Vec<std::path::PathBuf>> for FileList {
     }
 }
 
-impl<T: AsRef<[alloc::string::String]>> Setter<T> for FileList {
+impl<T: AsRef<str>> Setter<[T]> for FileList {
     #[inline(always)]
-    fn write_clipboard(&self, data: &T) -> SysResult<()> {
-        crate::raw::set_file_list(data.as_ref())
+    fn write_clipboard(&self, data: &[T]) -> SysResult<()> {
+        crate::raw::set_file_list(data)
     }
 }
 

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -142,6 +142,13 @@ impl Getter<alloc::vec::Vec<std::path::PathBuf>> for FileList {
     }
 }
 
+impl<T: AsRef<str>> Setter<T> for FileList {
+    #[inline(always)]
+    fn write_clipboard(&self, data: &T) -> SysResult<()> {
+        crate::raw::set_file_list(data.as_ref())
+    }
+}
+
 ///Format for bitmap images i.e. `CF_BITMAP`.
 ///
 ///Both `Getter` and `Setter` expects image as header and rgb payload

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ pub trait Getter<Type> {
 ///Describes format setter, specifying data type as type param
 ///
 ///Default implementations only perform write, without opening/closing clipboard
-pub trait Setter<Type> {
+pub trait Setter<Type: ?Sized> {
     ///Writes content of `data` onto clipboard, returning whether it was successful or not
     fn write_clipboard(&self, data: &Type) -> SysResult<()>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 //!assert_eq!(result, text)
 //!```
 
-#![no_std]
+// #![no_std]
 #![warn(missing_docs)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::style))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 //!assert_eq!(result, text)
 //!```
 
-// #![no_std]
+#![no_std]
 #![warn(missing_docs)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::style))]
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -595,7 +595,9 @@ pub fn set_bitmap(data: &[u8]) -> SysResult<()> {
 
 
 ///Set files to clipboard.
-pub fn set_file_list(file_list: &str) -> SysResult<()> {
+pub fn set_file_list(paths: &[String]) -> SysResult<()> {
+    let file_list = paths.join("\x00");
+
     use winapi::shared::windef::POINT;
     #[repr(C, packed(1))]
     pub struct DROPFILES {

--- a/tests/test_clip.rs
+++ b/tests/test_clip.rs
@@ -1,21 +1,14 @@
 use clipboard_win::{Getter, Setter, Clipboard, is_format_avail};
-use clipboard_win::formats::{RawData, Unicode, Bitmap, CF_TEXT, CF_UNICODETEXT, CF_BITMAP, FileList};
+use clipboard_win::formats::{RawData, Unicode, Bitmap, CF_TEXT, CF_UNICODETEXT, CF_BITMAP, FileList, CF_HDROP};
 
-#[test]
-fn should_work_with_filelist() {
-    // cargo test --features std should_work_with_filelist -- --exact --nocapture
-    // https://stackoverflow.com/questions/54585804/how-to-run-a-specific-unit-test-in-rust
-    // https://github.com/DoumanAsh/clipboard-win/issues/10
-
+fn should_set_file_list() {
     let _clip = Clipboard::new_attempts(10).expect("Open clipboard");
+    let path = std::fs::canonicalize("tests/test-image.bmp").expect("to get abs path").display().to_string();
+    FileList.write_clipboard(&path).expect("set file to copy");
 
-    let vec1 = vec!["C:/sandbox/0normal.abc"];
-    // let vec2 = vec!["C:/sandbox/0 acdt_json2.json.abc"];
-
-    let mut paths_joined = vec1.join("\x00");
-    paths_joined.push_str("\x00\x00");
-
-    FileList.write_clipboard(&paths_joined).expect("write paths");
+    let mut set_files = Vec::<String>::with_capacity(1);
+    FileList.read_clipboard(&mut set_files).expect("read");
+    assert_eq!(set_files, [path]);
 }
 
 fn should_work_with_bitmap() {
@@ -134,6 +127,8 @@ fn clipboard_should_work() {
     assert!(is_format_avail(CF_BITMAP));
     run!(should_work_with_string);
     assert!(is_format_avail(CF_UNICODETEXT));
+    run!(should_set_file_list);
+    assert!(is_format_avail(CF_HDROP));
     run!(should_work_with_wide_string);
     run!(should_work_with_bytes);
     run!(should_work_with_set_empty_string);

--- a/tests/test_clip.rs
+++ b/tests/test_clip.rs
@@ -3,12 +3,18 @@ use clipboard_win::formats::{RawData, Unicode, Bitmap, CF_TEXT, CF_UNICODETEXT, 
 
 fn should_set_file_list() {
     let _clip = Clipboard::new_attempts(10).expect("Open clipboard");
-    let path = std::fs::canonicalize("tests/test-image.bmp").expect("to get abs path").display().to_string();
-    FileList.write_clipboard(&path).expect("set file to copy");
+    // Note that you will not be able to paste the paths below in Windows Explorer because Explorer
+    // does not play nice with canonicalize: https://github.com/rust-lang/rust/issues/42869.
+    // Pasting in Explorer works fine with regular, non-UNC paths.
+    let paths = vec![
+        std::fs::canonicalize("tests/test-image.bmp").expect("to get abs path").display().to_string(),
+        std::fs::canonicalize("tests/formats.rs").expect("to get abs path").display().to_string(),
+    ];
+    FileList.write_clipboard(&paths).expect("set file to copy");
 
-    let mut set_files = Vec::<String>::with_capacity(1);
+    let mut set_files = Vec::<String>::with_capacity(2);
     FileList.read_clipboard(&mut set_files).expect("read");
-    assert_eq!(set_files, [path]);
+    assert_eq!(set_files, paths);
 }
 
 fn should_work_with_bitmap() {

--- a/tests/test_clip.rs
+++ b/tests/test_clip.rs
@@ -1,5 +1,22 @@
 use clipboard_win::{Getter, Setter, Clipboard, is_format_avail};
-use clipboard_win::formats::{RawData, Unicode, Bitmap, CF_TEXT, CF_UNICODETEXT, CF_BITMAP};
+use clipboard_win::formats::{RawData, Unicode, Bitmap, CF_TEXT, CF_UNICODETEXT, CF_BITMAP, FileList};
+
+#[test]
+fn should_work_with_filelist() {
+    // cargo test --features std should_work_with_filelist -- --exact --nocapture
+    // https://stackoverflow.com/questions/54585804/how-to-run-a-specific-unit-test-in-rust
+    // https://github.com/DoumanAsh/clipboard-win/issues/10
+
+    let _clip = Clipboard::new_attempts(10).expect("Open clipboard");
+
+    let vec1 = vec!["C:/sandbox/0normal.abc"];
+    // let vec2 = vec!["C:/sandbox/0 acdt_json2.json.abc"];
+
+    let mut paths_joined = vec1.join("\x00");
+    paths_joined.push_str("\x00\x00");
+
+    FileList.write_clipboard(&paths_joined).expect("write paths");
+}
 
 fn should_work_with_bitmap() {
     let _clip = Clipboard::new_attempts(10).expect("Open clipboard");

--- a/tests/test_clip.rs
+++ b/tests/test_clip.rs
@@ -6,7 +6,7 @@ fn should_set_file_list() {
     // Note that you will not be able to paste the paths below in Windows Explorer because Explorer
     // does not play nice with canonicalize: https://github.com/rust-lang/rust/issues/42869.
     // Pasting in Explorer works fine with regular, non-UNC paths.
-    let paths = vec![
+    let paths = [
         std::fs::canonicalize("tests/test-image.bmp").expect("to get abs path").display().to_string(),
         std::fs::canonicalize("tests/formats.rs").expect("to get abs path").display().to_string(),
     ];


### PR DESCRIPTION
I want to add setting files on the clipboard according to these links

https://stackoverflow.com/questions/25708895/how-to-copy-files-by-win32-api-functions-and-paste-by-ctrlv-in-my-desktop
https://forums.codeguru.com/showthread.php?565003-SetClipboardData()-to-Copy-File
https://forum.lazarus.freepascal.org/index.php?topic=51601.0
https://stackoverflow.com/questions/27278659/copy-a-file-to-clipboard-in-delphi
https://devblogs.microsoft.com/oldnewthing/20130520-00/?p=4313
https://learn.microsoft.com/en-us/windows/win32/shell/clipboard#cf_hdrop
https://github.com/luapower/winapi/blob/master/winapi/clipboard.lua#L187
https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/ns-shlobj_core-dropfiles
https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/UI/Shell/struct.DROPFILES.html
https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Foundation/struct.BOOL.html
https://github.com/gabdube/native-windows-gui/blob/10f2ac484b25368abc286f4d90562c3a27f22595/native-windows-gui/src/events.rs
https://github.com/alex8088/clipboard-files/blob/master/src/clip_win.cc

I get an error in the test that I added, though:

```
C:\Users\UMRH\repos\clipboard-win>cargo test should_work_with_filelist -- --exact --nocapture
   Compiling clipboard-win v4.4.2 (C:\Users\UMRH\repos\clipboard-win)
    Finished test [unoptimized + debuginfo] target(s) in 2.60s
     Running unittests src\lib.rs (target\debug\deps\clipboard_win-accf31e6a3daf1f9.exe)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests\formats.rs (target\debug\deps\formats-882388a362906242.exe)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s

     Running tests\test_clip.rs (target\debug\deps\test_clip-66edde24978329a6.exe)

running 1 test
0x9b75fef48
0x12cb0e047a0
0x12cb0dedcb0
20
0x12cb0dedcb0
48
error: test failed, to rerun pass '--test test_clip'

Caused by:
  process didn't exit successfully: `C:\Users\UMRH\repos\clipboard-win\target\debug\deps\test_clip-66edde24978329a6.exe should_work_with_filelist --exact --nocapture` (exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)
```

Occasionally, I will get

```
(exit code: 0xc0000374, STATUS_HEAP_CORRUPTION)
```

instead of

```
(exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)
```

so I suspect I am doing memory management wrong somehow. If anyone has any pointers (pun) on how to figure that part out, I would greatly appreciate it!

I had to disable `no_std` because I couldn't figure out how to get the code to run otherwise. Apologies for my rookie Rust skills.

Background: I am writing a file manager app in the tauri framework (https://tauri.app/) to learn rust. I come from a python background.

The funny thing is that the code above works for the first copy action in the sense that I am actually able to paste the file in Explorer. If I try to copy another file afterwards my Tauri app crashes with no stack trace